### PR TITLE
Adding configuration for foxess inverter

### DIFF
--- a/contrib/foxess/foxess.cfg
+++ b/contrib/foxess/foxess.cfg
@@ -1,0 +1,36 @@
+#
+# Modpoll configuration for the Fox ESS inverter
+# Expanded from information provided here: https://github.com/StealthChesnut/HA-FoxESS-Modbus/wiki/Data-Register-Reference---H1-AC1
+#
+device,foxess,1
+poll,holding_register,31000,30,BE_BE
+ref,pv1-voltage,31000,int16,rw,
+ref,pv1-current,31001,int16,rw,
+ref,pv1-power,31002,int16,rw,
+ref,pv2-voltage,31003,int16,rw,
+ref,pv2-current,31004,int16,rw,
+ref,pv2-power,31005,int16,rw,
+ref,grid-voltage,31006,int16,rw,
+ref,generated-current,31007,int16,rw,
+ref,generated-power,31008,int16,rw,
+ref,grid-frequency,31009,int16,rw,
+ref,r10,31010,int16,rw,
+ref,r11,31011,int16,rw,
+ref,r12,31012,int16,rw,
+ref,r13,31013,int16,rw,
+ref,grid-power,31014,int16,rw,
+ref,r15,31015,int16,rw,
+ref,load-power,31016,int16,rw,
+ref,r17,31017,int16,rw,
+ref,temp-ambient,31018,int16,rw,
+ref,temp-inverter,31019,int16,rw,
+ref,battery-voltage,31020,int16,rw,
+ref,battery-current,31021,int16,rw,
+ref,battery-discharge-power,31022,int16,rw,
+ref,temp-battery,31023,int16,rw,
+ref,battery-soc,31024,int16,rw,
+ref,r25,31025,int16,rw,
+ref,r26,31026,int16,rw,
+ref,state,31027,int16,rw,
+ref,inverter-mode,31028,int16,rw,
+ref,meter-type,31029,int16,rw,


### PR DESCRIPTION
This configuration file is for the foxess inverter used in my solar panel installation. Credit to @StealthChesnut for getting me started with: https://github.com/StealthChesnut/HA-FoxESS-Modbus/wiki/Data-Register-Reference---H1-AC1 I've added further values based on a comparison of data with what's reported from the Fox android app.

-Mark