### PR TITLE
Added options and timeout for Modbus RTU

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 exclude =
     docs/conf.py,
+max-line-length = 120

--- a/modpoll/arg_parser.py
+++ b/modpoll/arg_parser.py
@@ -28,6 +28,8 @@ def get_parser():
                         help='Response time-out seconds for MODBUS devices, Defaults to 3.0')
     parser.add_argument('-o', '--export', default=None,
                         help='The file name to export references/registers')
+    parser.add_argument('-p', '--print-result', action='store_true',
+                        help='Print received data.')
     parser.add_argument('--mqtt-host', default=None,
                         help='MQTT server address. Skip MQTT setup if not specified')
     parser.add_argument('--mqtt-port', default=1883, type=int,
@@ -50,6 +52,8 @@ def get_parser():
                         help="Path to ca keychain")
     parser.add_argument('--mqtt-tls-version', default=None, choices=['tlsv1.2', 'tlsv1.1', 'tlsv1'],
                         help='TLS protocol version, can be one of tlsv1.2 tlsv1.1 or tlsv1')
+    parser.add_argument('--mqtt-single', action='store_true',
+                        help='Publish each value in a single topic. If not specified groups all values in a single topic.')
     parser.add_argument('--diagnostics-rate', default=0, type=float,
                         help='Time in seconds as publishing period for each device diagnostics')
     parser.add_argument('--autoremove', action='store_true',
@@ -60,6 +64,4 @@ def get_parser():
                         help='Add timestamp to the result')
     parser.add_argument('--delay', default=0, type=int,
                         help='Time to delay sending first request in seconds after connecting. Default to 0')
-    parser.add_argument('--mqtt-single', action='store_true',
-                        help='Publish each value in a single topic. If not specified groups all values in a single topic.')
     return parser

--- a/modpoll/main.py
+++ b/modpoll/main.py
@@ -9,7 +9,8 @@ import json
 
 from modpoll.arg_parser import get_parser
 from modpoll.mqtt_task import mqttc_setup, mqttc_close, mqttc_receive
-from modpoll.modbus_task import modbus_setup, modbus_poll, modbus_publish, modbus_publish_diagnostics, modbus_export, modbus_close, modbus_write_coil, modbus_write_register
+from modpoll.modbus_task import modbus_setup, modbus_poll, modbus_publish, modbus_publish_diagnostics, modbus_export, \
+    modbus_close, modbus_write_coil, modbus_write_register
 
 LOG_SIMPLE = "%(asctime)s | %(levelname).1s | %(name)s | %(message)s"
 log = None
@@ -98,7 +99,7 @@ def app(name="modpoll"):
                     reg = json.loads(payload)
                     if "coil" == reg["object_type"]:
                         if modbus_write_coil(device_name, reg["address"], reg["value"]):
-                            log.info(f"")
+                            log.info("")
                     elif "holding_register" == reg["object_type"]:
                         modbus_write_register(device_name, reg["address"], reg["value"])
                 except json.decoder.JSONDecodeError:

--- a/modpoll/modbus_task.py
+++ b/modpoll/modbus_task.py
@@ -362,7 +362,7 @@ def modbus_setup(config, event):
         else:
             parity = "N"
         master = ModbusSerialClient(method="rtu", port=args.rtu, stopbits=1, bytesize=8, parity=parity,
-                                    baudrate=int(args.rtu_baud), reset_socket=True)
+                                    baudrate=int(args.rtu_baud), timeout=args.timeout, reset_socket=True)
     elif args.tcp:
         master = ModbusTcpClient(args.tcp, args.tcp_port, timeout=args.timeout, reset_socket=True)
     else:

--- a/modpoll/modbus_task.py
+++ b/modpoll/modbus_task.py
@@ -291,7 +291,7 @@ def parse_config(csv_reader):
             elif "input_register" == fc:
                 function_code = 4
                 if size > 123:
-                    log.error(f"Too many registers (max. 123). Ignoring poller.")
+                    log.error(f"Too many registers (max. 123): {size}. Ignoring poller.")
                     continue
             else:
                 log.warning(f"Unknown function code ({fc}) ignoring poller.")
@@ -336,7 +336,7 @@ def load_config(file):
             decoded_content = response.content.decode('utf-8')
             csv_reader = csv.reader(decoded_content.splitlines(), delimiter=',')
             parse_config(csv_reader)
-    except requests.RequestException as exception:
+    except requests.RequestException:
         with open(file, "r") as f:
             f.seek(0)
             csv_reader = csv.reader(f)

--- a/modpoll/modbus_task.py
+++ b/modpoll/modbus_task.py
@@ -387,8 +387,9 @@ def modbus_poll():
                     return
                 event_exit.wait(timeout=args.interval)
     master.close()
-    # Always printout result
-    modbus_print()
+    # printout result, if -p or --print-result are set
+    if args.print_result:
+        modbus_print()
 
 
 def modbus_write_coil(device_name, address: int, value):


### PR DESCRIPTION
* Added: Option to print result (currently it's always printed and spams the logfile) with `-p` or `--print-result`
* Added: Timeout was missing for the Modbus RTU function and therefore not applied
* Changed: Fixed some Flake8 errors