### PR TITLE
Ensure pymodbus is installed with serial support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:$PYTHON_TAG
 ARG APP_TAG="0.6.2"
 WORKDIR /app
 
-RUN pip3 install modpoll==$APP_TAG
+RUN pip3 install modpoll==$APP_TAG pymodbus[serial]
 
 COPY docker-entrypoint.sh .
 ENTRYPOINT ["sh", "./docker-entrypoint.sh"]


### PR DESCRIPTION
Fixes an issue with the docker container when trying to use serial devices.

Prior to this change running
```
modpoll --rtu /dev/ttyUSB0 --config https://raw.githubusercontent.com/gavinying/modpoll/master/examples/modsim.csv
```

within the docker container would cause the following error:

```
Traceback (most recent call last):
  File "/home/tobias/.local/lib/python3.10/site-packages/pymodbus/client/serial.py", line 206, in connect
    self.socket = serial.serial_for_url(
NameError: name 'serial' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/tobias/.local/bin/modpoll", line 8, in <module>
    sys.exit(app())
  File "/home/tobias/.local/lib/python3.10/site-packages/modpoll/main.py", line 84, in app
    modbus_poll()
  File "/home/tobias/.local/lib/python3.10/site-packages/modpoll/modbus_task.py", line 429, in modbus_poll
    master.connect()
  File "/home/tobias/.local/lib/python3.10/site-packages/pymodbus/client/serial.py", line 217, in connect
    except serial.SerialException as msg:
NameError: name 'serial' is not defined
```

This error is fixed by installing pymodbus with serial support.