### PR TITLE
Added float16 support for Morningstar solar inverters

### DIFF
--- a/contrib/morningstar/tristar.csv
+++ b/contrib/morningstar/tristar.csv
@@ -1,0 +1,65 @@
+device,MSChargeControler,1,,
+poll,holding_register,1,123,BE_BE
+ref,Charge Current,16,float16,r
+ref,Array Current,17,float16,r
+ref,Battery Terminal Voltage,18,float16,r
+ref,Array Voltage,19,float16,r
+ref,Load Voltage,20,float16,r
+ref,Battery Current net,21,float16,r
+ref,Load Current,22,float16,r
+ref,Battery Sense Voltage,23,float16,r
+ref,Battery Voltage slow filter,24,float16,r
+ref,Battery Current net slow filter,25,float16,r
+ref,Heatsink Temperature,26,float16,r
+ref,Battery Temperature,27,float16,r
+ref,Ambient Temperature,28,float16,r
+ref,Remote Temperature Sensor Temperature,29,float16,r
+ref,Phase U Inductor Temperature,30,float16,r
+ref,Phase V Inductor Temperature,31,float16,r
+ref,Phase W Inductor Temperature,32,float16,r
+ref,Charge State,33,int16,r
+ref,Array Fault Bitfield,34,int16,r
+ref,Battery Voltage Slow Filter,35,float16,r
+ref,Battery Regulator Reference Voltage,36,float16,r
+ref,Battery Regulator Slave Voltage,37,float16,r
+ref,Ah Charge Resettable HI,38,int16,r
+ref,Ah Charge Resettable LO,39,int16,r
+ref,Ah Charge Total HI,40,int16,r
+ref,Ah Charge Total LO,41,int16,r
+ref,kWh Charge Resettable,42,int16,r
+ref,kWh Charge Total,43,int16,r
+ref,Battery Temp foldback 100% output limit,44,float16,r
+ref,Battery Temp foldback 0% output limit,45,float16,r
+ref,Load State,46,int16,r
+ref,Load Fault Bitfield,47,int16,r
+ref,Load Current Compensated LVD Voltage,48,float16,r
+ref,Load HVD Voltage,49,float16,r
+ref,Ah Load resettable HI,50,int16,r
+ref,Ah Load resettable LO,51,int16,r
+ref,Ah Load Total HI,52,int16,r
+ref,Ah Load Total LO,53,int16,r
+ref,Hourmeter HI,54,int16,r
+ref,Hourmeter LO,55,int16,r
+ref,Alarm Bitfield HI,56,int16,r
+ref,Alarm Bitfield LO,57,int16,r
+ref,DIP Switch Settings,58,int16,r
+ref,SOC LED State,59,int16,r
+ref,Charger Output Power,60,float16,r
+ref,Array Vmp,61,float16,r
+ref,Array Max Output Power,62,float16,r
+ref,Array Voc,63,float16,r
+ref,Array Target Voltage,64,float16,r
+ref,Minimum Battery Voltage (Daily),65,float16,r
+ref,Maximum Battery Voltage (Daily),66,float16,r
+ref,Ah Charge (Daily),67,float16,r
+ref,Ah Load (Daily),68,float16,r
+ref,Array Fault Bitfield,69,int16,r
+ref,Load Fault Bitfield,70,int16,r
+ref,Alarm Bitfield HI,71,int16,r
+ref,Alarm Bitfield LO,72,int16,r
+ref,Time in Absorption,73,int16,r
+ref,Time in Equalization,74,int16,r
+ref,Time in Float,75,int16,r
+ref,Max Array Voltage,76,float16,r
+ref,Charge Status LED Status,77,int16,r
+ref,In Lighting Mode,78,int16,r

--- a/modpoll/modbus_task.py
+++ b/modpoll/modbus_task.py
@@ -155,6 +155,9 @@ class Poller:
                 elif "int64" == ref.dtype:
                     ref.update_value(decoder.decode_64bit_int())
                     cur_ref += ref.ref_width
+                elif "float16" == ref.dtype:
+                    ref.update_value(decoder.decode_16bit_float())
+                    cur_ref += ref.ref_width
                 elif "float32" == ref.dtype:
                     ref.update_value(decoder.decode_32bit_float())
                     cur_ref += ref.ref_width
@@ -231,6 +234,8 @@ class Reference:
             self.ref_width = 4
         elif "uint64" == dtype:
             self.ref_width = 4
+        elif "float16" == dtype:
+            self.ref_width = 1
         elif "float32" == dtype:
             self.ref_width = 2
         elif "float64" == dtype:


### PR DESCRIPTION
Added support for float16 which is a type supported by pymodbus.

Added our CSV file for Morningstar Prostar solar charge controllers.  We tested it with the prostar product but it should work with other Morningstar models. 


