### PR TITLE
fix: rename doc include config_template.csv

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -9,7 +9,7 @@ It is mainly to describe the device address and register mappings.
 
 Here is the basic structure of modbus configure file.
 
-.. literalinclude:: ../examples/example.csv
+.. literalinclude:: ../examples/config_template.csv
    :language: default
    :emphasize-lines: 8-10
    :linenos:


### PR DESCRIPTION
The example configuration file wasn't appearing in the documentation.

I think this is the right fix?