### PR TITLE
fix: remove clean_session from MQTT v3.1.1 connect call

### DIFF
--- a/modpoll/mqtt_task.py
+++ b/modpoll/mqtt_task.py
@@ -186,8 +186,6 @@ class MqttHandler:
             }
             if self.mqtt_version == "5.0":
                 connect_kwargs["clean_start"] = self.clean_start_or_session
-            else:
-                connect_kwargs["clean_session"] = self.clean_start_or_session
 
             self.mqtt_client.connect(**connect_kwargs)
             self.mqtt_client.loop_start()

--- a/tests/test_mqtt_task.py
+++ b/tests/test_mqtt_task.py
@@ -149,6 +149,39 @@ def test_publish_skips_when_disconnected_qos0(monkeypatch):
     assert result is None
 
 
+def test_connect_mqtt_v311_omits_clean_session_kwarg(monkeypatch):
+    """paho-mqtt 2.x rejects clean_session in connect(); it is set on the Client constructor."""
+    handler = MqttHandler(
+        name="test_mqtt",
+        host="broker.local",
+        port=1883,
+        user=None,
+        password=None,
+        clientid="test_client",
+        qos=0,
+        mqtt_version="3.1.1",
+    )
+
+    assert handler.setup()
+
+    captured = {}
+
+    def fake_connect(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(handler.mqtt_client, "connect", fake_connect)
+    monkeypatch.setattr(handler.mqtt_client, "loop_start", lambda: None)
+
+    assert handler.connect() is True
+    assert "clean_session" not in captured
+    assert captured == {
+        "host": "broker.local",
+        "port": 1883,
+        "keepalive": 60,
+    }
+
+
 def test_publish_attempts_reconnect_when_disconnected_qos1(monkeypatch):
     handler = MqttHandler(
         name="test_mqtt",


### PR DESCRIPTION
## Summary

- Stop passing `clean_session` to `Client.connect()` for MQTT v3.1.1
- paho-mqtt 2.x only accepts `clean_session` on `Client` construction (already configured in `setup()`)
- Fixes immediate crash when connecting to a broker with the default MQTT version

Fixes #103

## Test plan

- [x] `pytest tests/test_mqtt_task.py -m "not integration"`

Made with [Cursor](https://cursor.com)